### PR TITLE
Fix wrong order of MPQ files in map-extractor.

### DIFF
--- a/map-extractor/System.cpp
+++ b/map-extractor/System.cpp
@@ -94,12 +94,12 @@ static const char* CONF_mpq_list[] = /**< List MPQs to extract from */
     "dbc.MPQ",          // Classic Only
     "lichking.MPQ",     // Wotlk
     "expansion.MPQ",    // TBC / Wotlk
+    "terrain.MPQ",      // Classic Only
     "patch.MPQ",        // TBC / Wotlk
     "patch-2.MPQ",      // TBC / Wotlk
     "patch-3.MPQ",      // TBC / Wotlk
     "patch-4.MPQ",      // TBC / Wotlk
     "patch-5.MPQ",      // TBC / Wotlk
-    "terrain.MPQ",      // Classic Only
 };
 /**
  * @brief


### PR DESCRIPTION
```
- Due to improper ordering, the newest ADT were not processed at all. This means disaster.
- All maps, vmaps and mmaps MUST be re-extracted
```
