### PR TITLE
Improvement made to getBuildNumber()

### DIFF
--- a/shared/ExtractorCommon.cpp
+++ b/shared/ExtractorCommon.cpp
@@ -88,8 +88,8 @@ FILE* openWoWExe()
 }
 
 /**
-*  This function loads up a binary file (WoW executable), then searches for a specified 
-*  group of hex values in order to locate and return the Build # of the file
+*  This function loads up a binary file (WoW executable), then searches for and returns
+*  the build number of the file. The build number is searched for in hex form.
 * 
 *  @PARAM sFilename is the filename of the WoW executable to be loaded
 *  @RETURN iBuild the build number of the WoW executable, or 0 if failed
@@ -98,107 +98,84 @@ int getBuildNumber()
 {
     int iBuild = -1; ///< build version # of the WoW executable (returned value)
 
-    bool bBuildFound = false;
-
-    /// hex values of the text/bytes we need to search for:
-    /// WoW [
-    int iHexValue_W = 0x57;
-    int iHexValue_o = 0x6F;
-    int iHexValue_space = 0x20;
-    int iHexValue_OpeningBracket = 0x5B; // [
-
     /// buffers used for working on the file's bytes
     unsigned char byteSearchBuffer[1]; ///< used for reading in a single character, ready to be
-                                       ///< tested for the required text we are searching for: "WoW [Rel"
+                                       ///< tested for the required text we are searching for: 1, 5, 6, or 8
     unsigned char jumpBytesBuffer[128]; ///< used for skipping past the bytes from the file's start
                                         ///< to the base # area, before we start searching for the base #, for faster processing
-    unsigned char jumpNonAssertionBytesBuffer[7]; ///< used for skipping past the bytes between the text being
-                                        ///< searched for and the Base #, so that we can then get at the Base #
-    unsigned char jumpAssertionBytesBuffer[26]; ///< skip the 'assertions enabled' part of the version string in an OS X based
-                                        ///< version of the game.
-    unsigned char buildNumber[6]; ///< stored here prior to conversion to an integer
+    unsigned char preWOTLKbuildNumber[3]; ///< will hold the last 3 digits of the build number
+    unsigned char postTBCbuildNumber[4]; ///< will hold the last 4 digits of the build number
+
+    // These do not include the first digit
+    // as the first digit is used to locate the possible location of the build number
+    // then the following bytes are grabbed, 3 for pre WOTLK, 4 for WOTLK and later.
+    // Those grabbed bytes are then compared with the below variables in order to idenity the exe's build
+    unsigned char vanillaBuild1[3] = { 0x30, 0x30, 0x35 };       // (5)875
+    unsigned char vanillaBuild2[3] = { 0x30, 0x30, 0x35 };       // (6)005
+    unsigned char vanillaBuild3[3] = { 0x30, 0x30, 0x35 };       // (6)141
+    unsigned char tbcBuild[3]      = { 0x36, 0x30, 0x36 };       // (8)606
+    unsigned char wotlkBuild[4]    = { 0x32, 0x33, 0x34, 0x30 }; // (1)2340
+    unsigned char cataBuild[4]     = { 0x35, 0x35, 0x39, 0x35 }; // (1)5595
+    unsigned char mopBuild[4]      = { 0x38, 0x34, 0x31, 0x34 }; // (1)8414
 
     FILE *pFile;
     if (!(pFile = openWoWExe()))
-        return 0; ///> failed to locate exe file
+    {
+        printf("\nFatal Error: failed to locate the WoW executable!\n\n");
+        printf("\nExiting program!!\n");
+        exit(0); ///> failed to locate exe file
+    }
 
     /// jump over as much of the file as possible, before we start searching for the base #
     for (int i = 0; i < 3300; i++)
         fread(jumpBytesBuffer, sizeof(jumpBytesBuffer), 1, pFile);
-
+       
     /// Search for the build #
-    while (!bBuildFound && fread(byteSearchBuffer, 1, 1, pFile))
+    while (fread(byteSearchBuffer, 1, 1, pFile))
     {
-        /// find W
-        if (byteSearchBuffer[0] == 0x57)
+        /// we are looking for 1, 5, 6, or 8
+        /// these values are the first digit of the build versions we are interested in
+
+        // Vanilla and TBC
+        if (byteSearchBuffer[0] == 0x35 || byteSearchBuffer[0] == 0x36 || byteSearchBuffer[0] == 0x38)
         {
-            /// is the next byte an o
-            fread(byteSearchBuffer, 1, 1, pFile);
-            if (byteSearchBuffer[0] == iHexValue_o)
-            {
-                /// is the next byte a W
-                fread(byteSearchBuffer, 1, 1, pFile);
-                if (byteSearchBuffer[0] == iHexValue_W)
-                {
-                    /// is the next byte a space
-                    fread(byteSearchBuffer, 1, 1, pFile);
-                    if (byteSearchBuffer[0] == iHexValue_space)
-                    {
-                        /// is the next byte an open square bracket
-                        fread(byteSearchBuffer, 1, 1, pFile);
-                        if (byteSearchBuffer[0] == iHexValue_OpeningBracket)
-                        {
-                            // Check for assertions
-                            unsigned char releaseBuffer[7];
-                            fread(releaseBuffer, sizeof(releaseBuffer), 1, pFile);
+            /// grab the next 4 bytes
+            fread(preWOTLKbuildNumber, sizeof(preWOTLKbuildNumber), 1, pFile);
 
-                            fread(byteSearchBuffer, 1, 1, pFile);
-                            if (byteSearchBuffer[0] == iHexValue_space)
-                            {
-                                /*
-                                 * Longer version name found. E.g.;
-                                 * WoW [Release Assertions Enabled] Build 5875
-                                 */
-                                fread(jumpAssertionBytesBuffer, sizeof(jumpAssertionBytesBuffer), 1, pFile);
-                            } else {
-                                /**
-                                 * Regular build version found. E.g.;
-                                 * WoW [Release] Build 5875
-                                 */
-                                /// grab data leading up to the build #
-                                fread(jumpNonAssertionBytesBuffer, sizeof(jumpNonAssertionBytesBuffer), 1, pFile);
-                            }
+            if (!memcmp(preWOTLKbuildNumber, vanillaBuild1, sizeof(preWOTLKbuildNumber))) /// build is Vanilla?
+                return 5875;
+            else if (!memcmp(preWOTLKbuildNumber, vanillaBuild2, sizeof(preWOTLKbuildNumber))) /// build is Vanilla?
+                return 6005;
+            else if (!memcmp(preWOTLKbuildNumber, vanillaBuild3, sizeof(preWOTLKbuildNumber))) /// build is Vanilla?
+                return 6141;
+            else if (!memcmp(preWOTLKbuildNumber, tbcBuild, sizeof(preWOTLKbuildNumber))) /// build is TBC?
+                return 8606;
+        }
 
-                            bBuildFound = true;
-                        }
-                    }
-                }
-            }
+        /// WOTLK, CATA, MoP
+        if (byteSearchBuffer[0] == 0x31)
+        {
+            /// grab the next 4 bytes
+            fread(postTBCbuildNumber, sizeof(postTBCbuildNumber), 1, pFile);
+
+            if (!memcmp(postTBCbuildNumber, wotlkBuild, sizeof(postTBCbuildNumber))) /// build is WOTLK?
+                return 12340;
+            else if (!memcmp(postTBCbuildNumber, cataBuild, sizeof(postTBCbuildNumber))) /// build is CATA?
+                return 15595;
+            else if (!memcmp(postTBCbuildNumber, mopBuild, sizeof(postTBCbuildNumber))) /// build is MoP?
+                return 18414;
         }
     }
 
-    if (!bBuildFound)
-    {
-        /// close the file
-        fclose(pFile); ///< housekeping
-        return 0; ///< we reached the end of the file without locating the build #, exit funcion
-    }
-
-    /// grab the bytes containing the number
-    fread(buildNumber, sizeof(buildNumber), 1, pFile);
-
-    /// place the build number into a string (easy conversion to int)
-    std::stringstream ss;
-    std::string sbuildNumber;
-    ss << buildNumber[0] << buildNumber[1] << buildNumber[2] << buildNumber[3] << buildNumber[4];
-    ss >> sbuildNumber;
-
-    fclose(pFile); ///< housekeping
-
-    /// convert build number into an int
-    iBuild = atoi(sbuildNumber.c_str());
-
-    return iBuild; ///< build # found
+    printf("\nFatal Error: failed to identify build version!\n\n");
+    printf("\nSupported build versions:\n");
+    printf("\nVanilla: 5875, 6005, 6141\n");
+    printf("TBC:      8606\n");
+    printf("WOTLK:    12340\n");
+    printf("CATA:     15595\n");
+    printf("MOP:      18414\n");
+    printf("\n\nExiting program!!\n");
+    exit(0);
 }
 
 /**


### PR DESCRIPTION
The function now searches for the build number itself. These happen to
be unique to each executable, therefore allowing the number itself to be
searched for rather than other unique text.

MoP onwards, the current method to locate the build number fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/extractor_projects/12)
<!-- Reviewable:end -->
