### PR TITLE
use canonical target names for zlib and bzip2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ add_library(vmap
     ${CMAKE_SOURCE_DIR}/src/game/vmap/ModelInstance.cpp
 )
 
-target_link_libraries(vmap g3dlite zlib)
+target_link_libraries(vmap g3dlite ZLIB::ZLIB)
 
 # Used for install targets in subdirs
 set(TOOLS_DIR "tools")

--- a/Movemap-Generator/CMakeLists.txt
+++ b/Movemap-Generator/CMakeLists.txt
@@ -67,7 +67,7 @@ else()
     target_link_libraries(${EXECUTABLE_NAME} ACE)
 endif()
 
-target_link_libraries(${EXECUTABLE_NAME} g3dlite vmap detour recast zlib shared)
+target_link_libraries(${EXECUTABLE_NAME} g3dlite vmap detour recast ZLIB::ZLIB shared)
 
 set(EXECUTABLE_LINK_FLAGS "")
 

--- a/vmap-extractor/CMakeLists.txt
+++ b/vmap-extractor/CMakeLists.txt
@@ -58,7 +58,7 @@ else()
     target_link_libraries(${EXECUTABLE_NAME} ACE)
 endif()
 
-target_link_libraries(${EXECUTABLE_NAME} loadlib libmpq g3dlite vmap bzip2 zlib)
+target_link_libraries(${EXECUTABLE_NAME} loadlib libmpq g3dlite vmap BZip2::BZip2 ZLIB::ZLIB)
 
 set(EXECUTABLE_LINK_FLAGS "")
 


### PR DESCRIPTION
target_link_library requires that the name given is either the library
name, or the cmake target name.
Therefore to use the bundled zlib or bzip2, we have to pass the actual name
of the targets, namely BZip2::BZip2 and ZLIB::ZLIB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/extractor_projects/14)
<!-- Reviewable:end -->
