### PR TITLE
Missing files for MMAP extraction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@
 
 # Used for install targets
 set(TOOLS_DIR "tools")
+set(EXTRACTOR_BINARIES_DIR "${CMAKE_SOURCE_DIR}/src/tools/Extractor_Binaries")
 
 set(SHARED_SRCS
     shared/dbcfile.cpp
@@ -145,6 +146,20 @@ target_link_libraries(mmap-extractor
 install(
     TARGETS mmap-extractor
     DESTINATION ${BIN_DIR}/${TOOLS_DIR}
+)
+
+install (
+	FILES "${EXTRACTOR_BINARIES_DIR}/MoveMapGen.sh"        
+         DESTINATION ${BIN_DIR}/${TOOLS_DIR}
+)
+install (
+	FILES "${EXTRACTOR_BINARIES_DIR}/offmesh.txt"        
+         DESTINATION ${BIN_DIR}/${TOOLS_DIR}
+)
+
+install (
+	FILES "${EXTRACTOR_BINARIES_DIR}/mmap_excluded.txt"        
+         DESTINATION ${BIN_DIR}/${TOOLS_DIR}
 )
 
 if(WIN32 AND MSVC)


### PR DESCRIPTION
Added installation of:
- MoveMapGen.sh
- offmesh.txt
- mmap_excluded.txt
To the bin/tools folder, otherwise extracting script will fail due to missing files.
Tested on Ubuntu 19.04

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/extractor_projects/15)
<!-- Reviewable:end -->
