### PR TITLE
Fix M1 vmap extraction error

### DIFF
--- a/map-extractor/System.cpp
+++ b/map-extractor/System.cpp
@@ -1405,6 +1405,23 @@ void LoadLocaleMPQFiles(int const locale)
     }
 
     switch (iCoreNumber) {
+        case CLIENT_TBC:
+        case CLIENT_WOTLK:
+            for (int i = 1; i < 5; ++i)
+            {
+                char ext[3] = "";
+                if (i > 1)
+                {
+                    sprintf(ext, "-%i", i);
+                }
+
+                sprintf(filename, "%s/Data/%s/patch-%s%s.MPQ", input_path, Locales[locale], Locales[locale], ext);
+                if (ClientFileExists(filename) && !OpenArchive(filename))
+                {
+                    printf("Error open patch archive: %s\n", filename);
+                }
+            }
+            break;
         case CLIENT_CATA:
             // prepare sorted list patches in locale dir and Data root
             Updates updates;

--- a/map-extractor/System.cpp
+++ b/map-extractor/System.cpp
@@ -1405,23 +1405,6 @@ void LoadLocaleMPQFiles(int const locale)
     }
 
     switch (iCoreNumber) {
-        case CLIENT_TBC:
-        case CLIENT_WOTLK:
-            for (int i = 1; i < 5; ++i)
-            {
-                char ext[3] = "";
-                if (i > 1)
-                {
-                    sprintf(ext, "-%i", i);
-                }
-
-                sprintf(filename, "%s/Data/%s/patch-%s%s.MPQ", input_path, Locales[locale], Locales[locale], ext);
-                if (!OpenArchive(filename))
-                {
-                    printf("Error open patch archive: %s\n", filename);
-                }
-            }
-            break;
         case CLIENT_CATA:
             // prepare sorted list patches in locale dir and Data root
             Updates updates;

--- a/vmap-extractor/wdtfile.cpp
+++ b/vmap-extractor/wdtfile.cpp
@@ -29,6 +29,10 @@
 WDTFile::WDTFile(HANDLE handle, char* file_name, char* file_name1): WDT(handle, file_name)
 {
     filename.assign(file_name1);
+    for (int i = 0; i < MAP_TILE_SIZE * MAP_TILE_SIZE; i++)
+    {
+        mapAreaInfo[i] = NULL;
+    }
 }
 
 bool WDTFile::init(char* map_id, unsigned int mapID)


### PR DESCRIPTION
- Fix M1 vmap extraction error
- Fix wrong error message for non-existing patch files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/extractor_projects/17)
<!-- Reviewable:end -->
