### PR TITLE
Fix MMap tile coordinate swap in filename and VMap loading

### DIFF
--- a/Movemap-Generator/MapBuilder.cpp
+++ b/Movemap-Generator/MapBuilder.cpp
@@ -332,7 +332,7 @@ namespace MMAP
         m_terrainBuilder->loadMap(mapID, tileX, tileY, meshData, m_magic);
 
         // get model data
-        m_terrainBuilder->loadVMap(mapID, tileY, tileX, meshData);
+        m_terrainBuilder->loadVMap(mapID, tileX, tileY, meshData);
 
         // if there is no data, give up now
         if (!meshData.solidVerts.size() && !meshData.liquidVerts.size())
@@ -836,7 +836,7 @@ namespace MMAP
 
             // file output
             char fileName[255];
-            sprintf(fileName, "mmaps/%03u%02i%02i.mmtile", mapID, tileY, tileX);
+            sprintf(fileName, "mmaps/%03u%02i%02i.mmtile", mapID, tileX, tileY);
             FILE* file = fopen(fileName, "wb");
             if (!file)
             {
@@ -902,7 +902,7 @@ namespace MMAP
     bool MapBuilder::shouldSkipTile(int mapID, int tileX, int tileY)
     {
         char fileName[255];
-        sprintf(fileName, "mmaps/%03u%02i%02i.mmtile", mapID, tileY, tileX);
+        sprintf(fileName, "mmaps/%03u%02i%02i.mmtile", mapID, tileX, tileY);
         FILE* file = fopen(fileName, "rb");
         if (!file)
         {


### PR DESCRIPTION
Fixes tileX/tileY argument swap in three locations:
- buildTile: loadVMap call used swapped arguments
- buildMoveMapTile: sprintf for .mmtile filename used swapped arguments
- shouldSkipTile: sprintf for .mmtile check used swapped arguments

This caused the MMap generator to write .mmtile files with incorrect names (tileY,tileX instead of tileX,tileY), making the server unable to load the generated navmesh tiles.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/Extractor_projects/35)
<!-- Reviewable:end -->
