### PR TITLE
Fix tile coordinate argument order and multiple extractor bugs

### DIFF
--- a/Movemap-Generator/IntermediateValues.cpp
+++ b/Movemap-Generator/IntermediateValues.cpp
@@ -294,7 +294,7 @@ namespace MMAP
         fclose(objFile);
 
         char tileString[25];
-        sprintf(tileString, "[%02u,%02u]: ", tileY, tileX);
+        sprintf(tileString, "[%02u,%02u]: ", tileX, tileY);
         printf("%sWriting debug output...                       \r", tileString);
 
         sprintf(objFileName, "meshes/%03u.map", mapID);

--- a/Movemap-Generator/MapBuilder.cpp
+++ b/Movemap-Generator/MapBuilder.cpp
@@ -140,7 +140,7 @@ namespace MMAP
             {
                 tileX = uint32(atoi(files[i].substr(7, 2).c_str()));
                 tileY = uint32(atoi(files[i].substr(4, 2).c_str()));
-                tileID = StaticMapTree::packTileID(tileY, tileX);
+                tileID = StaticMapTree::packTileID(tileX, tileY);
 
                 tiles->insert(tileID);
                 count++;

--- a/Movemap-Generator/generator.cpp
+++ b/Movemap-Generator/generator.cpp
@@ -171,6 +171,11 @@ bool handleArgs(int argc, char** argv,
 
             char* stileX = strtok(param, ",");
             char* stileY = strtok(NULL, ",");
+            if (!stileX || !stileY)
+            {
+                printf("Invalid tile format. Expected: tileX,tileY\n");
+                return false;
+            }
             int tilex = atoi(stileX);
             int tiley = atoi(stileY);
 

--- a/vmap-extractor/wdtfile.cpp
+++ b/vmap-extractor/wdtfile.cpp
@@ -135,6 +135,8 @@ WDTFile::~WDTFile(void)
     {
         delete mapAreaInfo[i];
     }
+    delete [] gWmoInstansName;
+    gWmoInstansName = NULL;
 }
 
 bool WDTFile::hasTerrain(int x, int y)

--- a/vmap-extractor/wmo.cpp
+++ b/vmap-extractor/wmo.cpp
@@ -661,7 +661,8 @@ bool ExtractSingleWmo(std::string& fname, int iCoreNumber, const void *szRawVMAP
     if (rchr != NULL)
     {
         char cpy[4];
-        strncpy((char*)cpy, rchr, 4);
+        strncpy((char*)cpy, rchr, sizeof(cpy) - 1);
+        cpy[sizeof(cpy) - 1] = '\0';
         for (int i = 0; i < 4; ++i)
         {
             int m = cpy[i];
@@ -708,8 +709,10 @@ bool ExtractSingleWmo(std::string& fname, int iCoreNumber, const void *szRawVMAP
         for (uint32 i = 0; i < froot.nGroups; ++i)
         {
             char temp[1024];
-            strcpy(temp, fname.c_str());
-            temp[fname.length() - 4] = 0;
+            strncpy(temp, fname.c_str(), sizeof(temp) - 1);
+            temp[sizeof(temp) - 1] = '\0';
+            if (fname.length() >= 4)
+                temp[fname.length() - 4] = '\0';
             char groupFileName[1024];
             sprintf(groupFileName, "%s_%03d.wmo", temp, i);
 


### PR DESCRIPTION
Tile coordinate fixes:
- MapBuilder.cpp: Fix swapped packTileID(tileY,tileX) -> packTileID(tileX,tileY) in discoverTiles() vmtile parsing. Ensures correct tile ID packing for vmap tile discovery.
- IntermediateValues.cpp: Fix swapped sprintf arguments in generateObjFile() debug output string. Display now correctly shows [tileX,tileY] format.

Additional safety fixes found during audit:
- generator.cpp: Add NULL checks after strtok() for --tile argument parsing. Prevents crash on malformed tile coordinates (e.g. missing comma).
- wdtfile.cpp: Delete gWmoInstansName array in destructor. Fixes memory leak of global WMO instance name strings allocated during WDT parsing.
- wmo.cpp: Replace unsafe strcpy() with strncpy() + bounds check when constructing WMO group filenames. Prevents stack buffer overflow on long paths.
- wmo.cpp: Fix strncpy missing null terminator when copying underscore suffix. Ensures cpy[] is always null-terminated for digit detection loop.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/Extractor_projects/36)
<!-- Reviewable:end -->
