### PR TITLE
Fix missing building geometry in mmaps + vmap-extractor regressions (#35/#36 fallout)

### DIFF
--- a/Movemap-Generator/MapBuilder.cpp
+++ b/Movemap-Generator/MapBuilder.cpp
@@ -140,7 +140,11 @@ namespace MMAP
             {
                 tileX = uint32(atoi(files[i].substr(7, 2).c_str()));
                 tileY = uint32(atoi(files[i].substr(4, 2).c_str()));
-                tileID = StaticMapTree::packTileID(tileX, tileY);
+                // Revert PR #36: keep the vmtile parse packing (tileY, tileX) so it
+                // matches the map parse below. .map and .vmtile files store the same
+                // physical tile in opposite coordinate order; packing them the same
+                // way here desyncs the IDs and double-enumerates tiles.
+                tileID = StaticMapTree::packTileID(tileY, tileX);
 
                 tiles->insert(tileID);
                 count++;

--- a/Movemap-Generator/MapBuilder.cpp
+++ b/Movemap-Generator/MapBuilder.cpp
@@ -332,7 +332,11 @@ namespace MMAP
         m_terrainBuilder->loadMap(mapID, tileX, tileY, meshData, m_magic);
 
         // get model data
-        m_terrainBuilder->loadVMap(mapID, tileX, tileY, meshData);
+        // NOTE: vmap (.vmtile) files are written by the vmap-extractor with the
+        // opposite tile-coordinate order to map (.map) files, so loadVMap must be
+        // called with tileY/tileX swapped relative to loadMap. Un-swapping this
+        // (PR #35) caused WMO/building geometry to be silently skipped.
+        m_terrainBuilder->loadVMap(mapID, tileY, tileX, meshData);
 
         // if there is no data, give up now
         if (!meshData.solidVerts.size() && !meshData.liquidVerts.size())

--- a/vmap-extractor/wdtfile.cpp
+++ b/vmap-extractor/wdtfile.cpp
@@ -29,6 +29,8 @@
 WDTFile::WDTFile(HANDLE handle, char* file_name, char* file_name1): WDT(handle, file_name)
 {
     filename.assign(file_name1);
+    // Initialize so the destructor's delete[] is safe for WDTs with no MWMO chunk.
+    gWmoInstansName = NULL;
     for (int i = 0; i < MAP_TILE_SIZE * MAP_TILE_SIZE; i++)
     {
         mapAreaInfo[i] = NULL;
@@ -119,6 +121,8 @@ bool WDTFile::init(char* map_id, unsigned int mapID)
                     WMOInstance inst(WDT, gWmoInstansName[id], mapID, 65, 65, dirfile);
                 }
                 delete[] gWmoInstansName;
+                // Null after free so the destructor's delete[] cannot double-free.
+                gWmoInstansName = NULL;
             }
         }
         WDT.seek((int)nextpos);

--- a/vmap-extractor/wmo.cpp
+++ b/vmap-extractor/wmo.cpp
@@ -660,9 +660,14 @@ bool ExtractSingleWmo(std::string& fname, int iCoreNumber, const void *szRawVMAP
     const char* rchr = strrchr(plain_name.c_str(), '_');
     if (rchr != NULL)
     {
-        char cpy[4];
-        strncpy((char*)cpy, rchr, sizeof(cpy) - 1);
-        cpy[sizeof(cpy) - 1] = '\0';
+        // Copy the full "_NNN" suffix (4 chars) so the digit count below sees all
+        // three digits and group files are detected/skipped. PR #36 copied only 3
+        // chars, dropping the last digit (p==2, never 3), so group files were
+        // processed as roots and the extractor failed reading non-existent
+        // sub-group files (e.g. *_000.wmo). cpy[5] + explicit NUL keeps it safe.
+        char cpy[5];
+        strncpy((char*)cpy, rchr, 4);
+        cpy[4] = '\0';
         for (int i = 0; i < 4; ++i)
         {
             int m = cpy[i];


### PR DESCRIPTION
## Fix missing building geometry in mmaps + vmap-extractor regressions (#35/#36 fallout)

### Problem
Generated mmaps were missing all WMO/building geometry — creatures path *around* buildings on the bare terrain instead of through them (most visible in town interiors, e.g. Thelsamar in Loch Modan). Separately, the `vmap-extractor` had two bugs introduced by #36: a double-free crash and broken WMO group-file extraction.

### Root cause & fixes
`.map` files (map-extractor) and `.vmtile` files (vmap-extractor) store the *same physical tile under opposite coordinate orders*. The Movemap generator has always bridged that with a deliberate swap; recent PRs broke it and added unrelated regressions. Four fixes:

1. **Restore the `loadVMap` tile-coordinate swap** (`MapBuilder.cpp`) — `buildTile()` must call `loadVMap(mapID, tileY, tileX)`, swapped relative to `loadMap`, to match the opposite on-disk vmtile order. #35 "un-swapped" it, so the generator looked for vmtile filenames that don't exist for ~70% of tiles and silently dropped all building geometry.

2. **Revert #36's `discoverTiles` `packTileID` change** (`MapBuilder.cpp`) — #36 packed the vmtile parse as `packTileID(tileX, tileY)` to match the map parse, but given the opposite ordering that desyncs vmtile- vs map-derived tile IDs and double-enumerates every tile. Restored `packTileID(tileY, tileX)` so both parses agree.

3. **Fix `gWmoInstansName` double-free / uninitialized delete** (`wdtfile.cpp`) — #36 added `delete[]` in `~WDTFile` to fix a leak, but the pointer is never initialized (garbage delete for WDTs with no `MWMO` chunk) and is already freed in `init()` without being nulled (double-free for the common `MWMO`+`MODF` case). Init to `NULL` in the constructor and null after the in-`init` free; leak fix preserved, destructor now safe in all cases.

4. **Fix WMO group-file detection** (`wmo.cpp`) — `ExtractSingleWmo()` skips group files (`_NNN` suffix) by counting digits and returning when `p == 3`. #36 shortened the `strncpy` from 4 to 3 chars, dropping the last digit so `p` was never 3; group files got processed as roots and extraction failed reading non-existent sub-group files (e.g. `*_000.wmo` → "Can't read … No such file"). Copy all four chars again, with `cpy[5]` + explicit NUL.

### ⚠️ Note for reviewers
Do **not** "fix" the coordinate mismatch in `StaticMapTree::getTileFileName()` instead — that function is shared with the live server's VMap loader (LoS/collision/height). Changing it breaks the running server unless every vmap is re-extracted. The correct, isolated fix is the call-site swap in (1).

### Verification (Zero, map 0)
| metric | before (#35) | after |
|---|---|---|
| total mmaps | 459 MB | 794 MB |
| map-0 mmaps | 183 MB | 268 MB |
| mmap build time | ~465 s | ~576 s |
| `0002850.mmtile` | 176 KB | 276 KB |
| `0002927.mmtile` | 254 KB | 614 KB |

Building geometry is now present in the navmesh; `vmap-extractor` completes with no "Error opening WMOGroup" failures, and generated mmtiles load correctly at runtime (`.mmap loc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/Extractor_projects/38)
<!-- Reviewable:end -->
