### PR TITLE
Fix maps-loop tile offsets for 4-digit map IDs

### DIFF
--- a/Movemap-Generator/MapBuilder.cpp
+++ b/Movemap-Generator/MapBuilder.cpp
@@ -155,8 +155,8 @@ namespace MMAP
             getDirContents(files, "maps", filter);
             for (uint32 i = 0; i < files.size(); ++i)
             {
-                tileY = uint32(atoi(files[i].substr(3, 2).c_str()));
-                tileX = uint32(atoi(files[i].substr(5, 2).c_str()));
+                tileY = uint32(atoi(files[i].substr(4, 2).c_str()));
+                tileX = uint32(atoi(files[i].substr(6, 2).c_str()));
                 tileID = StaticMapTree::packTileID(tileX, tileY);
 
                 if (tiles->insert(tileID).second)


### PR DESCRIPTION
The `AdjustSubstr length` commit widened the `.vmtile` parse in `MapBuilder::discoverTiles()` (offsets `4->5`, `7->8`) but left the `.map` parse directly below it on the old 3-digit offsets.

`.map` files are `%04u%02u%02u.map` (`MMMMYYXX.map`, no separators) → tileY at chars 4-5, tileX at 6-7. The current `substr(3,2)`/`substr(5,2)` straddle the wrong digits, so every terrain tile is enumerated with garbage coordinates. `TerrainBuilder::loadMap` then opens a non-existent `maps/MMMMYYXX.map`, no terrain loads, and the movemap build produces near-empty output in seconds.

This matches the report on the PR (no movemap data, ~33s build vs the usual several minutes).

Fix: shift to `substr(4,2)`/`substr(6,2)`, mirroring the `+1` shift already applied to the `.vmtile` parse. Pack order (`packTileID(tileX, tileY)`) is unchanged.

Stacks on `New3_to_4_Digits`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/Extractor_projects/40)
<!-- Reviewable:end -->
