### PR TITLE
[Tools] Carry loadlib reader in the extractor tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,10 @@ set(SHARED_SRCS
     shared/ExtractorCommon.h
 )
 
+# loadlib: mangos's own ADT/WDT/MPQ client-format reader. Lives here (not in
+# the third-party mangosDeps repo) so dep/ stays purely third-party libraries.
+add_subdirectory(loadlib)
+
 #=======================================================#
 #map-extractor
 #=======================================================#

--- a/loadlib/CMakeLists.txt
+++ b/loadlib/CMakeLists.txt
@@ -1,0 +1,29 @@
+#
+# This code is part of MaNGOS. Contributor & Copyright details are in AUTHORS/THANKS.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+
+project(LOADLIB)
+
+add_library(loadlib STATIC
+  loadlib.cpp
+  adt.cpp
+  wdt.cpp
+  mpq.cpp)
+
+target_include_directories(loadlib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(loadlib PUBLIC stormlib)

--- a/loadlib/adt.cpp
+++ b/loadlib/adt.cpp
@@ -49,6 +49,7 @@ bool isHole(int holes, int i, int j)
 ADT_file::ADT_file()
 {
     a_grid = 0;
+    memset(cells, 0, sizeof(cells));
 }
 
 ADT_file::~ADT_file()

--- a/loadlib/adt.cpp
+++ b/loadlib/adt.cpp
@@ -1,0 +1,216 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "adt.h"
+
+// Helper
+int holetab_h[4] = {0x1111, 0x2222, 0x4444, 0x8888};
+int holetab_v[4] = {0x000F, 0x00F0, 0x0F00, 0xF000};
+
+bool isHole(int holes, int i, int j)
+{
+    int testi = i / 2;
+    int testj = j / 4;
+    if (testi > 3)
+    {
+        testi = 3;
+    }
+    if (testj > 3)
+    {
+        testj = 3;
+    }
+    return (holes & holetab_h[testi] & holetab_v[testj]) != 0;
+}
+
+//
+// Adt file loader class
+//
+ADT_file::ADT_file()
+{
+    a_grid = 0;
+}
+
+ADT_file::~ADT_file()
+{
+    free();
+}
+
+void ADT_file::free()
+{
+    a_grid = 0;
+    FileLoader::free();
+}
+
+//
+// Adt file check function
+//
+bool ADT_file::prepareLoadedData()
+{
+    // Check parent
+    if (!FileLoader::prepareLoadedData())
+    {
+        return false;
+    }
+
+    // Check and prepare MHDR
+    a_grid = (adt_MHDR*)(GetData() + 8 + version->size);
+    if (!a_grid->prepareLoadedData())
+    {
+        return false;
+    }
+
+    // funny offsets calculations because there is no mapping for them and they have variable lengths
+    uint8* ptr = (uint8*)a_grid + a_grid->size + 8;
+    uint32 mcnk_count = 0;
+    memset(cells, 0, ADT_CELLS_PER_GRID * ADT_CELLS_PER_GRID * sizeof(adt_MCNK*));
+    while (ptr < GetData() + GetDataSize())
+    {
+        uint32 header = *(uint32*)ptr;
+        uint32 size = *(uint32*)(ptr + 4);
+        if (header == 'MCNK')
+        {
+            cells[mcnk_count / ADT_CELLS_PER_GRID][mcnk_count % ADT_CELLS_PER_GRID] = (adt_MCNK*)ptr;
+            ++mcnk_count;
+        }
+
+        // move to next chunk
+        ptr += size + 8;
+    }
+
+    if (mcnk_count != ADT_CELLS_PER_GRID * ADT_CELLS_PER_GRID)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool adt_MHDR::prepareLoadedData()
+{
+    if (fcc != 'MHDR')
+    {
+        return false;
+    }
+
+    if (size != sizeof(adt_MHDR) - 8)
+    {
+        return false;
+    }
+
+    // Check and prepare MCIN
+    if (offsMCIN && !getMCIN()->prepareLoadedData())
+    {
+        return false;
+    }
+
+    // Check and prepare MH2O
+    if (offsMH2O && !getMH2O()->prepareLoadedData())
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool adt_MCIN::prepareLoadedData()
+{
+    if (fcc != 'MCIN')
+    {
+        return false;
+    }
+
+    // Check cells data
+    for (int i = 0; i < ADT_CELLS_PER_GRID; i++)
+    {
+        for (int j = 0; j < ADT_CELLS_PER_GRID; j++)
+        {
+            if (cells[i][j].offsMCNK && !getMCNK(i, j)->prepareLoadedData())
+            {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+bool adt_MH2O::prepareLoadedData()
+{
+    if (fcc != 'MH2O')
+    {
+        return false;
+    }
+
+    // Check liquid data
+//    for (int i=0; i<ADT_CELLS_PER_GRID;i++)
+//        for (int j=0; j<ADT_CELLS_PER_GRID;j++)
+
+    return true;
+}
+
+bool adt_MCNK::prepareLoadedData()
+{
+    if (fcc != 'MCNK')
+    {
+        return false;
+    }
+
+    // Check height map
+    if (offsMCVT && !getMCVT()->prepareLoadedData())
+    {
+        return false;
+    }
+
+    // Check liquid data
+    if (offsMCLQ && !getMCLQ()->prepareLoadedData())
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool adt_MCVT::prepareLoadedData()
+{
+    if (fcc != 'MCVT')
+    {
+        return false;
+    }
+
+    if (size != sizeof(adt_MCVT) - 8)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool adt_MCLQ::prepareLoadedData()
+{
+    if (fcc != 'MCLQ')
+    {
+        return false;
+    }
+
+    return true;
+}

--- a/loadlib/adt.h
+++ b/loadlib/adt.h
@@ -1,0 +1,362 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef ADT_H
+#define ADT_H
+
+#include "loadlib.h"
+
+#define TILESIZE (533.33333f)
+#define CHUNKSIZE ((TILESIZE) / 16.0f)
+#define UNITSIZE (CHUNKSIZE / 8.0f)
+
+enum LiquidType
+{
+    LIQUID_TYPE_WATER = 0,
+    LIQUID_TYPE_OCEAN = 1,
+    LIQUID_TYPE_MAGMA = 2,
+    LIQUID_TYPE_SLIME = 3
+};
+
+//**************************************************************************************
+// ADT file class
+//**************************************************************************************
+#define ADT_CELLS_PER_GRID    16
+#define ADT_CELL_SIZE         8
+#define ADT_GRID_SIZE         (ADT_CELLS_PER_GRID*ADT_CELL_SIZE)
+
+//
+// Adt file height map chunk
+//
+class ADT_file;
+class adt_MCVT
+{
+        union
+        {
+            uint32 fcc;
+            char   fcc_txt[4];
+        };
+        uint32 size;
+    public:
+        float height_map[(ADT_CELL_SIZE + 1) * (ADT_CELL_SIZE + 1) + ADT_CELL_SIZE* ADT_CELL_SIZE];
+
+        bool  prepareLoadedData();
+};
+
+//
+// Adt file liquid map chunk (old)
+//
+class adt_MCLQ
+{
+        union
+        {
+            uint32 fcc;
+            char   fcc_txt[4];
+        };
+        uint32 size;
+    public:
+        float height1;
+        float height2;
+        struct liquid_data
+        {
+            uint32 light;
+            float  height;
+        } liquid[ADT_CELL_SIZE + 1][ADT_CELL_SIZE + 1];
+
+        // 1<<0 - ochen
+        // 1<<1 - lava/slime
+        // 1<<2 - water
+        // 1<<6 - all water
+        // 1<<7 - dark water
+        // == 0x0F - not show liquid
+        uint8 flags[ADT_CELL_SIZE][ADT_CELL_SIZE];
+        uint8 data[84];
+        bool  prepareLoadedData();
+};
+
+//
+// Adt file cell chunk
+//
+class adt_MCNK
+{
+        union
+        {
+            uint32 fcc;
+            char   fcc_txt[4];
+        };
+        uint32 size;
+    public:
+        uint32 flags;
+        uint32 ix;
+        uint32 iy;
+        uint32 nLayers;
+        uint32 nDoodadRefs;
+        uint32 offsMCVT;        // height map
+        uint32 offsMCNR;        // Normal vectors for each vertex
+        uint32 offsMCLY;        // Texture layer definitions
+        uint32 offsMCRF;        // A list of indices into the parent file's MDDF chunk
+        uint32 offsMCAL;        // Alpha maps for additional texture layers
+        uint32 sizeMCAL;
+        uint32 offsMCSH;        // Shadow map for static shadows on the terrain
+        uint32 sizeMCSH;
+        uint32 areaid;
+        uint32 nMapObjRefs;
+        uint16 holes;           // locations where models pierce the heightmap
+        uint16 pad;
+        uint16 s[2];
+        uint32 data1;
+        uint32 data2;
+        uint32 data3;
+        uint32 predTex;
+        uint32 nEffectDoodad;
+        uint32 offsMCSE;
+        uint32 nSndEmitters;
+        uint32 offsMCLQ;         // Liqid level (old)
+        uint32 sizeMCLQ;         //
+        float  zpos;
+        float  xpos;
+        float  ypos;
+        uint32 offsMCCV;         // offsColorValues in WotLK
+        uint32 props;
+        uint32 effectId;
+
+        bool   prepareLoadedData();
+        adt_MCVT* getMCVT()
+        {
+            if (offsMCVT)
+            {
+                return (adt_MCVT*)((uint8*)this + offsMCVT);
+            }
+            return 0;
+        }
+        adt_MCLQ* getMCLQ()
+        {
+            if (offsMCLQ)
+            {
+                return (adt_MCLQ*)((uint8*)this + offsMCLQ);
+            }
+            return 0;
+        }
+};
+
+//
+// Adt file grid chunk
+//
+class adt_MCIN
+{
+        union
+        {
+            uint32 fcc;
+            char   fcc_txt[4];
+        };
+        uint32 size;
+    public:
+        struct adt_CELLS
+        {
+            uint32 offsMCNK;
+            uint32 size;
+            uint32 flags;
+            uint32 asyncId;
+        } cells[ADT_CELLS_PER_GRID][ADT_CELLS_PER_GRID];
+
+        bool   prepareLoadedData();
+        // offset from begin file (used this-84)
+        adt_MCNK* getMCNK(int x, int y)
+        {
+            if (cells[x][y].offsMCNK)
+            {
+                return (adt_MCNK*)((uint8*)this + cells[x][y].offsMCNK - 84);
+            }
+            return 0;
+        }
+};
+
+#define ADT_LIQUID_HEADER_FULL_LIGHT   0x01
+#define ADT_LIQUID_HEADER_NO_HIGHT     0x02
+
+struct adt_liquid_header
+{
+    uint16 liquidType;             // Index from LiquidType.dbc
+    uint16 formatFlags;
+    float  heightLevel1;
+    float  heightLevel2;
+    uint8  xOffset;
+    uint8  yOffset;
+    uint8  width;
+    uint8  height;
+    uint32 offsData2a;
+    uint32 offsData2b;
+};
+
+//
+// Adt file liquid data chunk (new)
+//
+class adt_MH2O
+{
+    public:
+        union
+        {
+            uint32 fcc;
+            char   fcc_txt[4];
+        };
+        uint32 size;
+
+        struct adt_LIQUID
+        {
+            uint32 offsData1;
+            uint32 used;
+            uint32 offsData2;
+        } liquid[ADT_CELLS_PER_GRID][ADT_CELLS_PER_GRID];
+
+        bool   prepareLoadedData();
+
+        adt_liquid_header* getLiquidData(int x, int y)
+        {
+            if (liquid[x][y].used && liquid[x][y].offsData1)
+            {
+                return (adt_liquid_header*)((uint8*)this + 8 + liquid[x][y].offsData1);
+            }
+            return 0;
+        }
+
+        float* getLiquidHeightMap(adt_liquid_header* h)
+        {
+            if (h->formatFlags & ADT_LIQUID_HEADER_NO_HIGHT)
+            {
+                return 0;
+            }
+
+            if (h->offsData2b)
+            {
+                return (float*)((uint8*)this + 8 + h->offsData2b);
+            }
+            return 0;
+        }
+
+        uint8* getLiquidLightMap(adt_liquid_header* h)
+        {
+            if (h->formatFlags & ADT_LIQUID_HEADER_FULL_LIGHT)
+            {
+                return 0;
+            }
+
+            if (h->offsData2b)
+            {
+                if (h->formatFlags & ADT_LIQUID_HEADER_NO_HIGHT)
+                {
+                    return (uint8*)((uint8*)this + 8 + h->offsData2b);
+                }
+                return (uint8*)((uint8*)this + 8 + h->offsData2b + (h->width + 1) * (h->height + 1) * 4);
+            }
+            return 0;
+        }
+
+        uint32* getLiquidFullLightMap(adt_liquid_header* h)
+        {
+            if (!(h->formatFlags & ADT_LIQUID_HEADER_FULL_LIGHT))
+            {
+                return 0;
+            }
+
+            if (h->offsData2b)
+            {
+                if (h->formatFlags & ADT_LIQUID_HEADER_NO_HIGHT)
+                {
+                    return (uint32*)((uint8*)this + 8 + h->offsData2b);
+                }
+                return (uint32*)((uint8*)this + 8 + h->offsData2b + (h->width + 1) * (h->height + 1) * 4);
+            }
+            return 0;
+        }
+
+        uint64 getLiquidShowMap(adt_liquid_header* h)
+        {
+            if (h->offsData2a)
+            {
+                return *((uint64*)((uint8*)this + 8 + h->offsData2a));
+            }
+            else
+            {
+                return (uint64)0xFFFFFFFFFFFFFFFFLL;
+            }
+        }
+
+};
+
+//
+// Adt file header chunk
+//
+class adt_MHDR
+{
+        union
+        {
+            uint32 fcc;
+            char   fcc_txt[4];
+        };
+    public:
+        uint32 size;
+
+        uint32 flags;
+        uint32 offsMCIN;           // MCIN
+        uint32 offsTex;            // MTEX
+        uint32 offsModels;         // MMDX
+        uint32 offsModelsIds;      // MMID
+        uint32 offsMapObjects;     // MWMO
+        uint32 offsMapObjectsIds;  // MWID
+        uint32 offsDoodsDef;       // MDDF
+        uint32 offsObjectsDef;     // MODF
+        uint32 offsMFBO;           // MFBO
+        uint32 offsMH2O;           // MH2O
+        uint32 data1;
+        uint32 data2;
+        uint32 data3;
+        uint32 data4;
+        uint32 data5;
+    public:
+        bool prepareLoadedData();
+        adt_MCIN* getMCIN()
+        {
+            return offsMCIN ? (adt_MCIN*)((uint8*)&flags + offsMCIN) : 0;
+        }
+        adt_MH2O* getMH2O()
+        {
+            return offsMH2O ? (adt_MH2O*)((uint8*)&flags + offsMH2O) : 0;
+        }
+};
+
+class ADT_file : public FileLoader
+{
+    public:
+        bool prepareLoadedData();
+        ADT_file();
+        ~ADT_file();
+        void free();
+
+        adt_MHDR* a_grid;
+        adt_MCNK* cells[ADT_CELLS_PER_GRID][ADT_CELLS_PER_GRID];
+};
+
+bool isHole(int holes, int i, int j);
+
+#endif

--- a/loadlib/loadlib.cpp
+++ b/loadlib/loadlib.cpp
@@ -1,0 +1,313 @@
+//#define _CRT_SECURE_NO_DEPRECATE
+
+#include "loadlib.h"
+#include <cstdio>
+
+u_map_fcc MverMagic = { {'R','E','V','M'} };
+
+ChunkedFile::ChunkedFile()
+{
+    data = 0;
+    data_size = 0;
+}
+
+ChunkedFile::~ChunkedFile()
+{
+    free();
+}
+
+bool ChunkedFile::loadFile(HANDLE mpq, char* filename, bool log)
+{
+    free();
+    HANDLE file;
+    if (!SFileOpenFileEx(mpq, filename, SFILE_OPEN_FROM_MPQ, &file))
+    {
+        if (log)
+            printf("No such file %s\n", filename);
+        return false;
+    }
+
+    data_size = SFileGetFileSize(file, NULL);
+    data = new uint8[data_size];
+    SFileReadFile(file, data, data_size, NULL/*bytesRead*/, NULL);
+    parseChunks();
+    if (prepareLoadedData())
+    {
+        SFileCloseFile(file);
+        return true;
+    }
+
+    printf("Error loading %s\n", filename);
+    SFileCloseFile(file);
+    free();
+    return false;
+}
+
+bool ChunkedFile::prepareLoadedData()
+{
+    FileChunk* chunk = GetChunk("MVER");
+    if (!chunk)
+        return false;
+
+    // Check version
+    file_MVER* version = chunk->As<file_MVER>();
+    if (version->fcc != MverMagic.fcc)
+        return false;
+    if (version->ver != FILE_FORMAT_VERSION)
+        return false;
+    return true;
+}
+
+void ChunkedFile::free()
+{
+    for (auto chunk : chunks)
+        delete chunk.second;
+
+    chunks.clear();
+
+    delete[] data;
+    data = 0;
+    data_size = 0;
+}
+
+u_map_fcc InterestingChunks[] = {
+    { 'R', 'E', 'V', 'M' },
+    { 'N', 'I', 'A', 'M' },
+    { 'O', '2', 'H', 'M' },
+    { 'K', 'N', 'C', 'M' },
+    { 'T', 'V', 'C', 'M' },
+    { 'Q', 'L', 'C', 'M' }
+};
+
+bool IsInterestingChunk(u_map_fcc const& fcc)
+{
+    for (u_map_fcc const& f : InterestingChunks)
+        if (f.fcc == fcc.fcc)
+            return true;
+
+    return false;
+}
+
+void ChunkedFile::parseChunks()
+{
+    uint8* ptr = GetData();
+    while (ptr < GetData() + GetDataSize())
+    {
+        u_map_fcc header = *(u_map_fcc*)ptr;
+        uint32 size = 0;
+        if (IsInterestingChunk(header))
+        {
+            size = *(uint32*)(ptr + 4);
+            if (size <= data_size)
+            {
+                std::swap(header.fcc_txt[0], header.fcc_txt[3]);
+                std::swap(header.fcc_txt[1], header.fcc_txt[2]);
+
+                FileChunk* chunk = new FileChunk{ ptr, size };
+                chunk->parseSubChunks();
+                chunks.insert({ std::string(header.fcc_txt, 4), chunk });
+            }
+        }
+
+        // move to next chunk
+        ptr += size + 8;
+    }
+}
+
+FileChunk* ChunkedFile::GetChunk(std::string const& name)
+{
+    auto range = chunks.equal_range(name);
+    if (std::distance(range.first, range.second) == 1)
+        return range.first->second;
+
+    return NULL;
+}
+
+FileChunk::~FileChunk()
+{
+    for (auto subchunk : subchunks)
+        delete subchunk.second;
+
+    subchunks.clear();
+}
+
+void FileChunk::parseSubChunks()
+{
+    uint8* ptr = data + 8; // skip self
+    while (ptr < data + size)
+    {
+        u_map_fcc header = *(u_map_fcc*)ptr;
+        uint32 subsize = 0;
+        if (IsInterestingChunk(header))
+        {
+            subsize = *(uint32*)(ptr + 4);
+            if (subsize < size)
+            {
+                std::swap(header.fcc_txt[0], header.fcc_txt[3]);
+                std::swap(header.fcc_txt[1], header.fcc_txt[2]);
+
+                FileChunk* chunk = new FileChunk{ ptr, subsize };
+                chunk->parseSubChunks();
+                subchunks.insert({ std::string(header.fcc_txt, 4), chunk });
+            }
+        }
+
+        // move to next chunk
+        ptr += subsize + 8;
+    }
+}
+
+FileChunk* FileChunk::GetSubChunk(std::string const& name)
+{
+    auto range = subchunks.equal_range(name);
+    if (std::distance(range.first, range.second) == 1)
+        return range.first->second;
+
+    return NULL;
+}
+
+// list of mpq files for lookup most recent file version
+ArchiveSet gOpenArchives;
+
+ArchiveSetBounds GetArchivesBounds()
+{
+    return ArchiveSetBounds(gOpenArchives.begin(), gOpenArchives.end());
+}
+
+bool OpenArchive(char const* mpqFileName, HANDLE* mpqHandlePtr /*= NULL*/)
+{
+    HANDLE mpqHandle;
+
+    if (!SFileOpenArchive(mpqFileName, 0, MPQ_OPEN_READ_ONLY, &mpqHandle))
+        return false;
+
+    gOpenArchives.push_back(mpqHandle);
+
+    if (mpqHandlePtr)
+        *mpqHandlePtr = mpqHandle;
+
+    return true;
+}
+
+bool OpenNewestFile(char const* filename, HANDLE* fileHandlerPtr)
+{
+    for (ArchiveSet::const_reverse_iterator i = gOpenArchives.rbegin(); i != gOpenArchives.rend(); ++i)
+    {
+        // always prefer get updated file version
+        if (SFileOpenFileEx(*i, filename, SFILE_OPEN_FROM_MPQ, fileHandlerPtr))
+            return true;
+    }
+
+    return false;
+}
+
+bool ExtractFile(char const* mpq_name, std::string const& filename)
+{
+    for (ArchiveSet::const_reverse_iterator i = gOpenArchives.rbegin(); i != gOpenArchives.rend(); ++i)
+    {
+        HANDLE fileHandle;
+        if (!SFileOpenFileEx(*i, mpq_name, SFILE_OPEN_FROM_MPQ, &fileHandle))
+            continue;
+
+        if (SFileGetFileSize(fileHandle, NULL) == 0)              // some files removed in next updates and its reported  size 0
+        {
+            SFileCloseFile(fileHandle);
+            return true;
+        }
+
+        SFileCloseFile(fileHandle);
+
+        if (!SFileExtractFile(*i, mpq_name, filename.c_str(), SFILE_OPEN_FROM_MPQ))
+        {
+            printf("Can't extract file: %s\n", mpq_name);
+            return false;
+        }
+
+        return true;
+    }
+
+    printf("Extracting file not found: %s\n", filename.c_str());
+    return false;
+}
+
+
+void CloseArchives()
+{
+    for (ArchiveSet::const_iterator i = gOpenArchives.begin(); i != gOpenArchives.end(); ++i)
+        SFileCloseArchive(*i);
+    gOpenArchives.clear();
+}
+
+FileLoader::FileLoader()
+{
+    data = 0;
+    data_size = 0;
+    version = 0;
+}
+
+FileLoader::~FileLoader()
+{
+    free();
+}
+
+bool FileLoader::loadFile(char* filename, bool log)
+{
+    free();
+
+    HANDLE fileHandle = 0;
+
+    if (!OpenNewestFile(filename, &fileHandle))
+    {
+        if (log)
+            printf("No such file %s\n", filename);
+        return false;
+    }
+
+    data_size = SFileGetFileSize(fileHandle, NULL);
+
+    data = new uint8 [data_size];
+    if (!data)
+    {
+        SFileCloseFile(fileHandle);
+        return false;
+    }
+
+    if (!SFileReadFile(fileHandle, data, data_size, NULL, NULL))
+    {
+        if (log)
+            printf("Can't read file %s\n", filename);
+        SFileCloseFile(fileHandle);
+        return false;
+    }
+
+    SFileCloseFile(fileHandle);
+
+    // ToDo: Fix WDT errors...
+    if (!prepareLoadedData())
+    {
+        //printf("Error loading %s\n\n", filename);
+        //free();
+        return false;
+    }
+
+    return true;
+}
+
+bool FileLoader::prepareLoadedData()
+{
+    // Check version
+    version = (file_MVER*) data;
+    if (version->fcc != 'MVER')
+        return false;
+    if (version->ver != FILE_FORMAT_VERSION)
+        return false;
+    return true;
+}
+
+void FileLoader::free()
+{
+    if (data) delete[] data;
+    data = 0;
+    data_size = 0;
+    version = 0;
+}

--- a/loadlib/loadlib.h
+++ b/loadlib/loadlib.h
@@ -1,0 +1,167 @@
+/**
+ * This code is part of MaNGOS. Contributor & Copyright details are in AUTHORS/THANKS.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef LOAD_LIB_H
+#define LOAD_LIB_H
+
+#include "StormLib.h"
+#include <cstdint>
+#include <string>
+#include <deque>
+#include <map>
+
+#ifndef _WIN32
+using HANDLE = void*;
+#endif
+
+using int8   = int8_t;
+using int16  = int16_t;
+using int32  = int32_t;
+using int64  = int64_t;
+using uint8  = uint8_t;
+using uint16 = uint16_t;
+using uint32 = uint32_t;
+using uint64 = uint64_t;
+
+
+using ArchiveSet = std::deque<HANDLE>;
+using ArchiveSetBounds = std::pair<ArchiveSet::const_iterator, ArchiveSet::const_iterator>;
+
+
+/**
+* @brief Open a MPQ file archive and return the Archive HANDLE to the calling method.
+* @details Open an MPQ file archive and pushes to the list of opened archives.
+*  Use this method by opening the MPQ in their priority order, from the lowest to the highest priority.
+* @param[in] mpqFileName The location of the MPQ, including its filename.
+* @param[out] mpqHandlePtr A pointer to the handle to be retrieved.
+*
+* @pre The mpqFileName must point to an existing MPQ file.
+*
+* @returns `true` if the Archive has been opened successfully, `false` otherwise.
+*/
+bool OpenArchive(char const* mpqFileName, HANDLE* mpqHandlePtr = NULL);
+
+/**
+* @brief Open a file from an already opened MPQ file archive. Returns a handler to the requested file.
+* @details Open a file, given the filename, from an already opened MPQ file archive.
+* This method will take the opened archived depending on their priority. If A.mpq was opened before B.mpq and a the file exists within both
+* archives, the handle will point to the file contained in the archive B.mpq as it has the highest priority.
+* @param[in] filename The filename to be retrieved.
+* @param[in, out] fileHandlerPtr A pointer to the handle to be retrieved.
+*
+* @pre The filename must exist within at least one opened MPQ archive.
+*
+* @returns `true` if the file has been found in at least one archive, `false` otherwise.
+*/
+bool OpenNewestFile(char const* filename, HANDLE* fileHandlerPtr);
+
+/**
+* TODO
+*/
+ArchiveSetBounds GetArchivesBounds();
+
+/**
+* @brief Extract a file from a given MPQ file archive.
+* @details Extract a file from a given MPQ file archive to the filesystem.
+* This method will take the opened archived depending on their priority. If A.mpq was opened before B.mpq and a the file exists within both
+* archives, the extract file will be the one contained in the archive B.mpq as it has the highest priority.
+* @param[in] mpq_name The location of the MPQ file archive to open.
+* @param[in] filename The filename to be extracted from the MPQ.
+*/
+bool ExtractFile(char const* mpq_name, std::string const& filename);
+
+/**
+* @brief Closed all handlers to MPQ file archives.
+*/
+void CloseArchives();
+
+#define FILE_FORMAT_VERSION    18
+
+union u_map_fcc
+{
+    char   fcc_txt[4];
+    uint32 fcc;
+};
+
+//
+// File version chunk
+//
+struct file_MVER
+{
+    union
+    {
+        uint32 fcc;
+        char   fcc_txt[4];
+    };
+    uint32 size;
+    uint32 ver;
+};
+
+class FileLoader
+{
+        uint8*  data;
+        uint32  data_size;
+    public:
+        virtual bool prepareLoadedData();
+        uint8* GetData()     {return data;}
+        uint32 GetDataSize() {return data_size;}
+
+        file_MVER* version;
+        FileLoader();
+        ~FileLoader();
+        bool loadFile(char* filename, bool log = true);
+        virtual void free();
+};
+
+/**************************************
+    Required for MoP data extraction
+    ================================
+ **************************************/
+class FileChunk
+{
+public:
+    ~FileChunk();
+
+    uint8* data;
+    uint32 size;
+
+    template<class T>
+    T* As() { return (T*)data; }
+    void parseSubChunks();
+    std::multimap<std::string, FileChunk*> subchunks;
+    FileChunk* GetSubChunk(std::string const& name);
+};
+
+class ChunkedFile{
+public:
+    uint8  *data;
+    uint32  data_size;
+    uint8 *GetData()     {return data;}
+    uint32 GetDataSize() {return data_size;}
+
+    ChunkedFile();
+    virtual ~ChunkedFile();
+    bool prepareLoadedData();
+    bool loadFile(HANDLE mpq, char *filename, bool log = true);
+    void free();
+
+    void parseChunks();
+    std::multimap<std::string, FileChunk*> chunks;
+    FileChunk* GetChunk(std::string const& name);
+};
+#endif

--- a/loadlib/mpq.cpp
+++ b/loadlib/mpq.cpp
@@ -1,0 +1,77 @@
+#include "mpq.h"
+#include "StormLib.h"
+
+MPQFile::MPQFile(HANDLE file, const char* filename):
+    eof(false),
+    buffer(0),
+    pointer(0),
+    size(0)
+{
+    DWORD hi = 0;
+    size = SFileGetFileSize(file, &hi);
+
+    if (hi)
+    {
+        fprintf(stderr, "Can't open %s, size[hi] = %u!\n", filename, (uint32)hi);
+        SFileCloseFile(file);
+        eof = true;
+        return;
+    }
+
+    if (size <= 1)
+    {
+        fprintf(stderr, "Can't open %s, size = %zu!\n", filename, size);
+        SFileCloseFile(file);
+        eof = true;
+        return;
+    }
+
+    DWORD read = 0;
+    buffer = new char[size];
+    if (!SFileReadFile(file, buffer, size, &read, NULL) || size != read)
+    {
+        fprintf(stderr, "Can't read %s, size=%zu read=%u!\n", filename, size, read);
+        SFileCloseFile(file);
+        eof = true;
+        return;
+    }
+
+    SFileCloseFile(file);
+}
+
+size_t MPQFile::read(void* dest, size_t bytes)
+{
+    if (eof) return 0;
+
+    size_t rpos = pointer + bytes;
+    if (rpos > size)
+    {
+        bytes = size - pointer;
+        eof = true;
+    }
+
+    memcpy(dest, &(buffer[pointer]), bytes);
+
+    pointer = rpos;
+
+    return bytes;
+}
+
+void MPQFile::seek(int offset)
+{
+    pointer = offset;
+    eof = (pointer >= size);
+}
+
+void MPQFile::seekRelative(int offset)
+{
+    pointer += offset;
+    eof = (pointer >= size);
+}
+
+void MPQFile::close()
+{
+    if (buffer) delete[] buffer;
+    buffer = 0;
+    eof = true;
+}

--- a/loadlib/mpq.h
+++ b/loadlib/mpq.h
@@ -1,0 +1,47 @@
+#ifndef MPQ_H
+#define MPQ_H
+
+#include "loadlib.h"
+
+using namespace std;
+
+class MPQFile
+{
+        //MPQHANDLE handle;
+        bool eof;
+        char* buffer;
+        size_t pointer, size;
+
+        // disable copying
+        MPQFile(const MPQFile& f);
+        void operator=(const MPQFile& f);
+
+    public:
+        MPQFile(HANDLE file, const char* filename);    // filenames are not case sensitive
+        ~MPQFile()
+    {
+        close();
+    }
+        size_t read(void* dest, size_t bytes);
+        size_t getSize() { return size; }
+        size_t getPos() { return pointer; }
+        char* getBuffer() { return buffer; }
+        char* getPointer() { return buffer + pointer; }
+        bool isEof() { return eof; }
+        void seek(int offset);
+        void seekRelative(int offset);
+        void close();
+};
+
+inline void flipcc(char* fcc)
+{
+    char t;
+    t = fcc[0];
+    fcc[0] = fcc[3];
+    fcc[3] = t;
+    t = fcc[1];
+    fcc[1] = fcc[2];
+    fcc[2] = t;
+}
+
+#endif

--- a/loadlib/wdt.cpp
+++ b/loadlib/wdt.cpp
@@ -1,0 +1,62 @@
+//#define _CRT_SECURE_NO_DEPRECATE
+
+#include "wdt.h"
+
+bool wdt_MWMO::prepareLoadedData()
+{
+    if (fcc != 'MWMO')
+        return false;
+    return true;
+}
+
+bool wdt_MPHD::prepareLoadedData()
+{
+    if (fcc != 'MPHD')
+        return false;
+    return true;
+}
+
+bool wdt_MAIN::prepareLoadedData()
+{
+    if (fcc != 'MAIN')
+        return false;
+    return true;
+}
+
+WDT_file::WDT_file()
+{
+    mphd = 0;
+    main = 0;
+    wmo  = 0;
+}
+
+WDT_file::~WDT_file()
+{
+    free();
+}
+
+void WDT_file::free()
+{
+    mphd = 0;
+    main = 0;
+    wmo  = 0;
+    FileLoader::free();
+}
+
+bool WDT_file::prepareLoadedData()
+{
+    // Check parent
+    if (!FileLoader::prepareLoadedData())
+        return false;
+
+    mphd = (wdt_MPHD*)((uint8*)version + version->size + 8);
+    if (!mphd->prepareLoadedData())
+        return false;
+    main = (wdt_MAIN*)((uint8*)mphd + mphd->size + 8);
+    if (!main->prepareLoadedData())
+        return false;
+    wmo = (wdt_MWMO*)((uint8*)main + main->size + 8);
+    if (!wmo->prepareLoadedData())
+        return false;
+    return true;
+}

--- a/loadlib/wdt.h
+++ b/loadlib/wdt.h
@@ -1,0 +1,94 @@
+/**
+ * This code is part of MaNGOS. Contributor & Copyright details are in AUTHORS/THANKS.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef WDT_H
+#define WDT_H
+#include "loadlib.h"
+
+//**************************************************************************************
+// WDT file class and structures
+//**************************************************************************************
+#define WDT_MAP_SIZE 64
+
+class wdt_MWMO
+{
+        union
+        {
+            uint32 fcc;
+            char   fcc_txt[4];
+        };
+    public:
+        uint32 size;
+        bool prepareLoadedData();
+};
+
+class wdt_MPHD
+{
+        union
+        {
+            uint32 fcc;
+            char   fcc_txt[4];
+        };
+    public:
+        uint32 size;
+
+        uint32 data1;
+        uint32 data2;
+        uint32 data3;
+        uint32 data4;
+        uint32 data5;
+        uint32 data6;
+        uint32 data7;
+        uint32 data8;
+        bool   prepareLoadedData();
+};
+
+class wdt_MAIN
+{
+        union
+        {
+            uint32 fcc;
+            char   fcc_txt[4];
+        };
+    public:
+        uint32 size;
+
+        struct adtData
+        {
+            uint32 exist;
+            uint32 data1;
+        } adt_list[64][64];
+
+        bool   prepareLoadedData();
+};
+
+class WDT_file : public FileLoader
+{
+    public:
+        bool   prepareLoadedData();
+
+        WDT_file();
+        ~WDT_file();
+        void free();
+
+        wdt_MPHD* mphd;
+        wdt_MAIN* main;
+        wdt_MWMO* wmo;
+};
+
+#endif


### PR DESCRIPTION
## Carry loadlib in the extractor tree

`loadlib` is mangos's own ADT/WDT/MPQ client-format reader — not a third-party
library like StormLib or zlib. It currently lives in the shared `mangosDeps`
repo, which makes that repo not-quite-purely-third-party and leaves m3 unable to
align its `dep/` with the other cores (m3 vendors a Cata-specific reader).

This moves the reader into the extractor tree, where it's actually consumed. The
extractor targets already link the `loadlib` target; this only relocates where
it's built. Source is unchanged (verbatim from `mangosDeps/loadlib`).

**Paired with** the matching `mangosDeps` PR that removes `loadlib` there.

### Merge ordering (important)
The two define a target named `loadlib`. A core must never pin a combination
where *both* repos provide it (duplicate target) or *neither* does (missing
target). So after both merge, each core bumps **both** submodule pins in one
commit. No core breaks until it bumps; either PR can merge first.

Build-verified on m0 (server-zero) with both branches wired in: configure +
extractor build clean.

**Pair:** mangos/mangosDeps#43

---
*Second commit initializes `ADT_file::cells` in the constructor — clears the cppcheck/Codacy error-prone finding the moved file surfaced (latent issue carried in from the old mangosDeps copy).*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/Extractor_projects/42)
<!-- Reviewable:end -->
