### PR TITLE
[Extractors] Thread map-extractor tile conversion

### DIFF
--- a/map-extractor/System.cpp
+++ b/map-extractor/System.cpp
@@ -24,6 +24,11 @@
 
 #include <stdio.h>
 #include <set>
+#include <atomic>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <vector>
 
 #include "dbcfile.h"
 #include <mpq.h>
@@ -82,6 +87,13 @@ enum Extract
 int   CONF_extract = EXTRACT_MAP | EXTRACT_DBC; /**< Select data for extract */
 bool  CONF_allow_height_limit       = true;     /**< Allows to limit minimum height */
 float CONF_use_minHeight            = -500.0f;  /**< Default minimum height */
+uint32 CONF_threads = 0;            ///< Worker threads for tile conversion; 0 = auto-detect cores, 1 = serial.
+
+/// Serializes MPQ archive reads. StormLib mutates a shared per-archive file
+/// position with no internal locking, so concurrent reads from one handle
+/// race (unsafe on Linux). Held only around the archive read in ConvertADT;
+/// the parse/pack/write that follows runs fully parallel.
+std::mutex g_mpqReadMutex;
 
 bool  CONF_allow_float_to_int      = false;      /**< Allows float to int conversion */
 float CONF_float_to_int8_limit     = 2.0f;      /**< Max accuracy = val/256 */
@@ -181,6 +193,8 @@ void Usage(char* prg)
     printf("                         size, but also accuracy\n");
     printf("   -e, --extract #       extract specified client data. 1 = maps, 2 = DBCs,\n");
     printf("                         3 = both. Defaults to extracting both.\n");
+    printf("   -t, --threads #       worker threads for map conversion. 0 = auto-detect\n");
+    printf("                         cores (default), 1 = serial.\n");
     printf("\n");
     printf(" Example:\n");
     printf(" - use input path and do not flatten maps:\n");
@@ -252,6 +266,16 @@ bool HandleArgs(int argc, char** argv)
             {
                 Usage(argv[0]);
             }
+        }
+        else if (strcmp(argv[i], "-t") == 0 || strcmp(argv[i], "--threads") == 0)
+        {
+            param = argv[++i];
+            if (!param)
+            {
+                return false;
+            }
+
+            CONF_threads = atoi(param);
         }
         else if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0)
         {
@@ -516,19 +540,23 @@ float selectUInt16StepStore(float maxDiff)
     return 65535 / maxDiff;
 }
 
-uint16 area_flags[ADT_CELLS_PER_GRID][ADT_CELLS_PER_GRID];      /**< Temporary grid data store */
+// Per-tile working buffers. thread_local so each worker thread owns a private
+// copy: with one thread this is identical to the former plain globals, and it
+// lets ConvertADT run on several tiles concurrently without trampling shared
+// scratch. ConvertADT fully (re)writes/resets these per tile before reading.
+thread_local uint16 area_flags[ADT_CELLS_PER_GRID][ADT_CELLS_PER_GRID];      /**< Temporary grid data store */
 
-float V8[ADT_GRID_SIZE][ADT_GRID_SIZE];                         /**< TODO */
-float V9[ADT_GRID_SIZE + 1][ADT_GRID_SIZE + 1];                 /**< TODO */
-uint16 uint16_V8[ADT_GRID_SIZE][ADT_GRID_SIZE];                 /**< TODO */
-uint16 uint16_V9[ADT_GRID_SIZE + 1][ADT_GRID_SIZE + 1];         /**< TODO */
-uint8  uint8_V8[ADT_GRID_SIZE][ADT_GRID_SIZE];                  /**< TODO */
-uint8  uint8_V9[ADT_GRID_SIZE + 1][ADT_GRID_SIZE + 1];          /**< TODO */
+thread_local float V8[ADT_GRID_SIZE][ADT_GRID_SIZE];                         /**< TODO */
+thread_local float V9[ADT_GRID_SIZE + 1][ADT_GRID_SIZE + 1];                 /**< TODO */
+thread_local uint16 uint16_V8[ADT_GRID_SIZE][ADT_GRID_SIZE];                 /**< TODO */
+thread_local uint16 uint16_V9[ADT_GRID_SIZE + 1][ADT_GRID_SIZE + 1];         /**< TODO */
+thread_local uint8  uint8_V8[ADT_GRID_SIZE][ADT_GRID_SIZE];                  /**< TODO */
+thread_local uint8  uint8_V9[ADT_GRID_SIZE + 1][ADT_GRID_SIZE + 1];          /**< TODO */
 
-uint16 liquid_entry[ADT_CELLS_PER_GRID][ADT_CELLS_PER_GRID];    /**< TODO */
-uint8 liquid_flags[ADT_CELLS_PER_GRID][ADT_CELLS_PER_GRID];     /**< TODO */
-bool  liquid_show[ADT_GRID_SIZE][ADT_GRID_SIZE];                /**< TODO */
-float liquid_height[ADT_GRID_SIZE + 1][ADT_GRID_SIZE + 1];      /**< TODO */
+thread_local uint16 liquid_entry[ADT_CELLS_PER_GRID][ADT_CELLS_PER_GRID];    /**< TODO */
+thread_local uint8 liquid_flags[ADT_CELLS_PER_GRID][ADT_CELLS_PER_GRID];     /**< TODO */
+thread_local bool  liquid_show[ADT_GRID_SIZE][ADT_GRID_SIZE];                /**< TODO */
+thread_local float liquid_height[ADT_GRID_SIZE + 1][ADT_GRID_SIZE + 1];      /**< TODO */
 
 /**
  * @brief
@@ -542,10 +570,15 @@ bool ConvertADT(char* filename, char* filename2, uint32 build)
 {
     ADT_file adt;
 
-    if (!adt.loadFile(filename))
     {
-        printf("Error: Failed to load ADT file: %s\n", filename);
-        return false;
+        // loadFile reads the whole ADT into memory; everything after this is
+        // in-memory work, so the MPQ lock is held only for the read itself.
+        std::lock_guard<std::mutex> mpqLock(g_mpqReadMutex);
+        if (!adt.loadFile(filename))
+        {
+            printf("Error: Failed to load ADT file: %s\n", filename);
+            return false;
+        }
     }
 
     adt_MCIN* cells = adt.a_grid->getMCIN();
@@ -555,9 +588,23 @@ bool ConvertADT(char* filename, char* filename2, uint32 build)
         return false;
     }
 
+    // Zero every per-tile scratch buffer up front so a tile's output can never
+    // inherit residual data from a previously processed tile. Cells a tile does
+    // not fully overwrite (e.g. liquid height outside the liquid bounds) are
+    // dead to the server (gated by the liquid flags), but they still land in the
+    // .map file -- leaving them stale made the bytes depend on tile order, which
+    // is non-deterministic once tiles are processed across threads.
+    memset(area_flags, 0, sizeof(area_flags));
+    memset(V8, 0, sizeof(V8));
+    memset(V9, 0, sizeof(V9));
+    memset(uint16_V8, 0, sizeof(uint16_V8));
+    memset(uint16_V9, 0, sizeof(uint16_V9));
+    memset(uint8_V8, 0, sizeof(uint8_V8));
+    memset(uint8_V9, 0, sizeof(uint8_V9));
     memset(liquid_show, 0, sizeof(liquid_show));
     memset(liquid_flags, 0, sizeof(liquid_flags));
     memset(liquid_entry, 0, sizeof(liquid_entry));
+    memset(liquid_height, 0, sizeof(liquid_height));
 
     // Prepare map header
     map_fileheader map;
@@ -1207,8 +1254,6 @@ bool ConvertADT(char* filename, char* filename2, uint32 build)
  */
 void ExtractMapsFromMpq(uint32 build)
 {
-    char mpq_filename[1024];
-    char output_filename[1024];
     char mpq_map_name[1024];
 
     printf("\n Extracting maps...\n");
@@ -1222,8 +1267,8 @@ void ExtractMapsFromMpq(uint32 build)
     path += "/maps/";
     CreateDir(path);
 
-    uint32 success_count = 0;
-    uint32 failed_count = 0;
+    std::atomic<uint32> success_count{0};
+    std::atomic<uint32> failed_count{0};
 
     printf("\n Converting map files\n");
     for (uint32 z = 0; z < map_count; ++z)
@@ -1261,19 +1306,51 @@ void ExtractMapsFromMpq(uint32 build)
         }
         printf("  WDT indicates %u ADT files exist for this map\n", adt_exist_in_wdt);
 
+        // Collect the existing tiles, then convert them across CONF_threads
+        // workers (0 = auto-detect cores). Each tile writes its own independent
+        // .map output file, so the result is identical regardless of thread
+        // count or completion order.
+        std::queue<std::pair<uint32, uint32> > tileQueue;   // (tileX, tileY)
         for (uint32 y = 0; y < WDT_MAP_SIZE; ++y)
         {
             for (uint32 x = 0; x < WDT_MAP_SIZE; ++x)
             {
                 // Check bit 0 only: this is the ADT existence flag
-                if (!(wdt.main->adt_list[y][x].exist & 0x1))
+                if (wdt.main->adt_list[y][x].exist & 0x1)
                 {
-                    continue;
+                    tileQueue.push(std::make_pair(x, y));
                 }
-                ++adt_count;
-                sprintf(mpq_filename, "World\\Maps\\%s\\%s_%u_%u.adt", map_ids[z].name, map_ids[z].name, x, y);
-                sprintf(output_filename, "%s/maps/%04u%02u%02u.map", output_path, map_ids[z].id, y, x);
-                if (ConvertADT(mpq_filename, output_filename, build))
+            }
+        }
+        adt_count = static_cast<uint32>(tileQueue.size());
+
+        uint32 nThreads = CONF_threads ? CONF_threads : std::thread::hardware_concurrency();
+        if (nThreads < 1)
+        {
+            nThreads = 1;
+        }
+
+        std::mutex queueMutex;
+        auto worker = [&]()
+        {
+            char tile_mpq[1024];
+            char tile_out[1024];
+            while (true)
+            {
+                uint32 tileX, tileY;
+                {
+                    std::lock_guard<std::mutex> lock(queueMutex);
+                    if (tileQueue.empty())
+                    {
+                        break;
+                    }
+                    tileX = tileQueue.front().first;
+                    tileY = tileQueue.front().second;
+                    tileQueue.pop();
+                }
+                sprintf(tile_mpq, "World\\Maps\\%s\\%s_%u_%u.adt", map_ids[z].name, map_ids[z].name, tileX, tileY);
+                sprintf(tile_out, "%s/maps/%04u%02u%02u.map", output_path, map_ids[z].id, tileY, tileX);
+                if (ConvertADT(tile_mpq, tile_out, build))
                 {
                     ++success_count;
                 }
@@ -1282,8 +1359,26 @@ void ExtractMapsFromMpq(uint32 build)
                     ++failed_count;
                 }
             }
-            // draw progress bar
-            printf(" Processing........................%d%%\r", (100 * (y + 1)) / WDT_MAP_SIZE);
+        };
+
+        if (nThreads <= 1)
+        {
+            // Serial path: one worker on this thread, identical to the
+            // pre-threading behaviour.
+            worker();
+        }
+        else
+        {
+            std::vector<std::thread> workers;
+            workers.reserve(nThreads);
+            for (uint32 t = 0; t < nThreads; ++t)
+            {
+                workers.emplace_back(worker);
+            }
+            for (std::thread& w : workers)
+            {
+                w.join();
+            }
         }
 
         if (adt_count > 0)
@@ -1296,8 +1391,8 @@ void ExtractMapsFromMpq(uint32 build)
         }
     }
     printf("\n\nMap extraction complete!\n");
-    printf("Successfully converted: %u tiles\n", success_count);
-    printf("Failed to convert: %u tiles\n", failed_count);
+    printf("Successfully converted: %u tiles\n", success_count.load());
+    printf("Failed to convert: %u tiles\n", failed_count.load());
     delete [] areas;
     delete [] map_ids;
 }


### PR DESCRIPTION
Adds `-t/--threads` to **map-extractor** and converts each map's ADT tiles across a worker pool (`0` = auto-detect cores, default; `1` = serial) — matching the movemap generator's threading model. Currently only mmap is threaded; map extraction is the first/slow stage.

**What changed (map-extractor/System.cpp only)**
- Per-map tile queue drained by N workers. Each `.map` output file is independent, so the result is identical regardless of thread count or completion order.
- Per-tile scratch buffers (area/height/liquid grids) are now `thread_local`.
- `success`/`failed` counters are `std::atomic`.
- MPQ reads are serialised by one mutex held only around the archive read in `ConvertADT`. StormLib mutates a shared per-archive file position with no internal lock, so concurrent reads from one handle are unsafe (notably on Linux). The parse/pack/write that follows runs in parallel.
- Zero every per-tile scratch buffer up front. Cells a tile doesn't fully overwrite (liquid height outside the liquid bounds — dead to the server via the liquid flags) previously kept residual bytes from the prior tile, which made `.map` bytes depend on tile order — non-deterministic once tiles run across threads. Zeroing makes output deterministic.

**Verified:** builds green (MSVC, via mangostwo's tree). The identical change in the mangosthree in-tree extractor was validated on the 4.3.4 client — full extraction at `--threads 1` vs auto produces **byte-for-byte identical** maps (7192 tiles), ~2.4× faster on 16 cores. (vmap-extractor threading is a separate follow-up — its structure here differs more.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/Extractor_projects/44)
<!-- Reviewable:end -->
