### PR TITLE
[Extractors] Thread vmap-extractor tile extraction

### DIFF
--- a/vmap-extractor/adtfile.cpp
+++ b/vmap-extractor/adtfile.cpp
@@ -35,12 +35,16 @@ bool ADTFile::init(uint32 map_num, uint32 tileX, uint32 tileY, StringSet& failed
 {
     HANDLE adtHandle;
 
+    // The archive open + read race the shared StormLib file position, so hold
+    // the MPQ lock around them; the in-memory parse that follows is unlocked.
+    std::unique_lock<std::mutex> mpqLock(g_mpqReadMutex);
     if (!OpenNewestFile(AdtFilename.c_str(), &adtHandle))
     {
         printf("Error initializing ADT %s\n", AdtFilename.c_str());
     }
 
     MPQFile ADT(adtHandle, AdtFilename.c_str());
+    mpqLock.unlock();
 
     if (ADT.isEof())
     {
@@ -63,7 +67,13 @@ bool ADTFile::init(uint32 map_num, uint32 tileX, uint32 tileY, StringSet& failed
 
     std::string AdtMapNumber = xMap + ' ' + yMap + ' ' + GetUniformName(filename);
 
-    std::string dirname = std::string(szWorkDirWmo) + "/dir_bin";
+    // Write this tile's placement records to a per-tile temp file rather than
+    // the shared dir_bin. A placement is several fwrites, so concurrent tiles
+    // sharing one handle would interleave (corrupt) records. ParseMapFiles
+    // concatenates these temps into dir_bin in tile order afterwards.
+    char tileSuffix[32];
+    sprintf(tileSuffix, "/dir_bin.%u_%u", tileX, tileY);
+    std::string dirname = std::string(szWorkDirWmo) + tileSuffix;
     FILE* dirfile;
     dirfile = fopen(dirname.c_str(), "ab");
     if (!dirfile)

--- a/vmap-extractor/model.cpp
+++ b/vmap-extractor/model.cpp
@@ -25,6 +25,9 @@
 #include <cassert>
 #include <algorithm>
 #include <cstdio>
+#include <condition_variable>
+#include <mutex>
+#include <set>
 
 #include <mpq.h>
 #include "model.h"
@@ -33,6 +36,16 @@
 #include "vmapexport.h"
 #include <ExtractorCommon.h>
 
+// Dedup model extraction across parallel tile workers. The FileExists()-then-
+// write check is a TOCTOU race once tiles run concurrently. One worker extracts
+// a given model; the rest WAIT until its file is on disk, because the placement
+// written straight after (ModelInstance) opens that file and silently drops the
+// spawn if it is missing.
+static std::mutex s_modelExtractMutex;
+static std::condition_variable s_modelExtractCv;
+static std::set<std::string> s_modelsInProgress;
+static std::set<std::string> s_modelsDone;
+
 Model::Model(std::string& filename) : filename(filename), vertices(0), indices(0), nIndices(0), boundingVertices(0), ok(false), headerClassicTBC(), headerOthers()
 {
 }
@@ -40,12 +53,14 @@ Model::Model(std::string& filename) : filename(filename), vertices(0), indices(0
 bool Model::open(StringSet& failedPaths, int iCoreNumber)
 {
     HANDLE mpqHandle;
+    std::unique_lock<std::mutex> mpqLock(g_mpqReadMutex);
     if (!OpenNewestFile(filename.c_str(), &mpqHandle))
     {
         printf("Error opening model file %s\n", filename.c_str());
         return false;
     }
     MPQFile f(mpqHandle, filename.c_str());
+    mpqLock.unlock();
 
     ok = !f.isEof();
 
@@ -303,18 +318,39 @@ bool ExtractSingleModel(std::string& origPath, std::string& fixedName, StringSet
     output += "/";
     output += fixedName;
 
-    if (FileExists(output.c_str()))
     {
-        return true;
+        std::unique_lock<std::mutex> lock(s_modelExtractMutex);
+        if (s_modelsDone.count(fixedName))
+        {
+            return true;
+        }
+        if (s_modelsInProgress.count(fixedName))
+        {
+            // Another worker is extracting this model; block until its file is
+            // written so the placement that follows can read it.
+            s_modelExtractCv.wait(lock, [&] { return s_modelsDone.count(fixedName) != 0; });
+            return true;
+        }
+        if (FileExists(output.c_str()))
+        {
+            s_modelsDone.insert(fixedName);
+            return true;
+        }
+        // Claim it, then extract outside the lock so distinct models convert in
+        // parallel.
+        s_modelsInProgress.insert(fixedName);
     }
 
     Model mdl(origPath);                                    // Possible changed fname
-    if (!mdl.open(failedPaths, iCoreNumber))
-    {
-        return false;
-    }
+    bool ok = mdl.open(failedPaths, iCoreNumber) && mdl.ConvertToVMAPModel(output, iCoreNumber, szRawVMAPMagic);
 
-    return mdl.ConvertToVMAPModel(output, iCoreNumber, szRawVMAPMagic);
+    {
+        std::lock_guard<std::mutex> lock(s_modelExtractMutex);
+        s_modelsInProgress.erase(fixedName);
+        s_modelsDone.insert(fixedName);
+    }
+    s_modelExtractCv.notify_all();
+    return ok;
 }
 
 void ExtractGameobjectModels(int iCoreNumber, const void *szRawVMAPMagic)

--- a/vmap-extractor/vmapexport.cpp
+++ b/vmap-extractor/vmapexport.cpp
@@ -28,6 +28,11 @@
 #include <list>
 #include <algorithm>
 #include <errno.h>
+#include <atomic>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <utility>
 
 #if defined WIN32
 #include <Windows.h>
@@ -145,6 +150,14 @@ static const char* kWOTLKMPQList[] =
 //static const char * szWorkDirMaps = ".\\Maps";
 char const szWorkDirWmo[]   = "./Buildings";
 char       szRawVMAPMagic[] = "VMAP000";
+
+uint32 CONF_threads = 0;            ///< Worker threads for tile extraction; 0 = auto-detect cores, 1 = serial.
+
+// Serializes MPQ archive reads. StormLib mutates a shared per-archive file
+// position with no internal lock, so concurrent reads from one handle race
+// (unsafe on Linux). Held around each OpenNewestFile + MPQFile read; the
+// parsing and geometry conversion that follow run in parallel.
+std::mutex g_mpqReadMutex;
 
 // Local testing functions
 
@@ -281,22 +294,102 @@ void ParseMapFiles(int iCoreNumber)
         WDTFile WDT(handleWDT, fn, map_ids[i].name);
         if (WDT.init(id, map_ids[i].id))
         {
-            printf(" Processing Map %u (%s)\n[", map_ids[i].id, map_ids[i].name);
+            printf(" Processing Map %u (%s)\n", map_ids[i].id, map_ids[i].name);
+
+            // Queue every tile slot; GetMap() returns NULL for absent ones.
+            std::queue<std::pair<int, int> > tileQueue;
             for (int x = 0; x < 64; ++x)
             {
                 for (int y = 0; y < 64; ++y)
                 {
+                    tileQueue.push(std::make_pair(x, y));
+                }
+            }
+
+            uint32 nThreads = CONF_threads ? CONF_threads : std::thread::hardware_concurrency();
+            if (nThreads < 1)
+            {
+                nThreads = 1;
+            }
+
+            uint32 mapId = map_ids[i].id;
+            std::mutex queueMutex;
+            std::mutex failedMutex;
+            auto worker = [&]()
+            {
+                StringSet localFailed;
+                while (true)
+                {
+                    int x, y;
+                    {
+                        std::lock_guard<std::mutex> lock(queueMutex);
+                        if (tileQueue.empty())
+                        {
+                            break;
+                        }
+                        x = tileQueue.front().first;
+                        y = tileQueue.front().second;
+                        tileQueue.pop();
+                    }
                     if (ADTFile* ADT = WDT.GetMap(x, y))
                     {
-                        //sprintf(id_filename,"%02u %02u %04u",x,y,map_ids[i].id);//!!!!!!!!!
-                        ADT->init(map_ids[i].id, x, y, failedPaths, iCoreNumber, szRawVMAPMagic);
+                        ADT->init(mapId, x, y, localFailed, iCoreNumber, szRawVMAPMagic);
                         delete ADT;
                     }
                 }
-                printf("#");
-                fflush(stdout);
+                std::lock_guard<std::mutex> lock(failedMutex);
+                failedPaths.insert(localFailed.begin(), localFailed.end());
+            };
+
+            if (nThreads <= 1)
+            {
+                // Serial path: one worker on this thread.
+                worker();
             }
-            printf("]\n");
+            else
+            {
+                std::vector<std::thread> workers;
+                workers.reserve(nThreads);
+                for (uint32 t = 0; t < nThreads; ++t)
+                {
+                    workers.emplace_back(worker);
+                }
+                for (std::thread& w : workers)
+                {
+                    w.join();
+                }
+            }
+
+            // Concatenate the per-tile temp files into dir_bin in tile order,
+            // so dir_bin is assembled in the same order no matter which worker
+            // wrote which tile, then remove the temps.
+            std::string dirBin = std::string(szWorkDirWmo) + "/dir_bin";
+            if (FILE* out = fopen(dirBin.c_str(), "ab"))
+            {
+                char copyBuf[8192];
+                for (int x = 0; x < 64; ++x)
+                {
+                    for (int y = 0; y < 64; ++y)
+                    {
+                        char tileSuffix[32];
+                        sprintf(tileSuffix, "/dir_bin.%u_%u", (uint32)x, (uint32)y);
+                        std::string tilePath = std::string(szWorkDirWmo) + tileSuffix;
+                        FILE* in = fopen(tilePath.c_str(), "rb");
+                        if (!in)
+                        {
+                            continue;
+                        }
+                        size_t n;
+                        while ((n = fread(copyBuf, 1, sizeof(copyBuf), in)) > 0)
+                        {
+                            fwrite(copyBuf, 1, n, out);
+                        }
+                        fclose(in);
+                        remove(tilePath.c_str());
+                    }
+                }
+                fclose(out);
+            }
         }
     }
 
@@ -595,6 +688,8 @@ void Usage(char* prg)
     printf("   -i, --input <path>     search path for game client archives\n");
     printf("   -s, --small           extract smaller vmaps by optimizing data. Reduces\n");
     printf("                         size by ~ 500MB\n");
+    printf("   -t, --threads #       worker threads for tile extraction. 0 = auto-detect\n");
+    printf("                         cores (default), 1 = serial.\n");
     printf("\n");
     printf(" Example:\n");
     printf(" - use data path and create larger vmaps:\n");
@@ -628,6 +723,18 @@ bool processArgv(int argc, char** argv)
 
             result = true;
             strcpy(input_path, param);
+        }
+        else if (strcmp(argv[i], "-t") == 0 || strcmp(argv[i], "--threads") == 0 )
+        {
+            param = argv[++i];
+            if (!param)
+            {
+                result = false;
+                break;
+            }
+
+            result = true;
+            CONF_threads = atoi(param);
         }
         else
         {

--- a/vmap-extractor/vmapexport.h
+++ b/vmap-extractor/vmapexport.h
@@ -27,6 +27,7 @@
 
 #include <string>
 #include <set>
+#include <mutex>
 
 /**
  * @brief
@@ -47,6 +48,11 @@ enum ModelFlags
 
 extern char const szWorkDirWmo[]; /**< TODO */
 //extern const char* szRawVMAPMagic; /**< vmap magic string for extracted raw vmap data */
+
+/// Serializes MPQ archive reads across worker threads (StormLib's shared
+/// per-archive file position has no internal lock). Held around each
+/// OpenNewestFile + MPQFile read; defined in vmapexport.cpp.
+extern std::mutex g_mpqReadMutex;
 
 /**
  * @brief Test if the specified file exists in the building directory


### PR DESCRIPTION
Adds `-t/--threads` to **vmap-extractor** and processes each map's ADT tiles across a worker pool (`0` = auto-detect cores, default; `1` = serial), matching the movemap generator. Companion to the map-extractor threading in #44; together with mmap, all three extractors then support `--threads`.

**Concurrency handling**
- **MPQ reads** — StormLib mutates a shared per-archive file position with no internal lock, so concurrent reads from one handle race (notably on Linux). The archive open+read at the two parallel-path sites (`ADTFile::init` and `Model::open`) are held under one mutex; the in-memory parse + geometry conversion that follow run in parallel. *(This read-lock is the throughput limiter; per-thread archive handles are a possible follow-up.)*
- **Model dedup** — the `FileExists()`-then-write check is a TOCTOU race. A worker claims a model, extracts it, and any worker referencing the same model **blocks on a condition variable until its file is on disk** — `ModelInstance` opens that file next and drops the placement if it's missing.
- **dir_bin** — each tile writes its own temp file (a placement is several `fwrite`s; a shared handle would interleave records), concatenated in tile order afterwards.
- **failedPaths** — per-worker, merged after.

WMO geometry is extracted by the serial `ExtractWmo` pass that runs first, so no WMO archive read happens on the parallel path. This tree emits **no order-dependent doodad IDs**, so the output is **deterministic regardless of thread count**.

**Verification**
- Builds green (MSVC, via mangostwo's tree).
- The identical change in the **mangosthree** in-tree extractor was validated on a 4.3.4 client: same model + vmap file sets and identical `dir_bin` records vs serial — and that's where the model-dedup condition-variable wait was found to be required (without it ~156 placements were dropped).
- I could **not** runtime-test this shared build locally (it auto-detects as WotLK and I only have a Cata client). A maintainer with a matching client running `--threads 1` vs auto should see **byte-identical** output (no doodad-ID non-determinism here). Recommend that check before merge.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/Extractor_projects/45)
<!-- Reviewable:end -->
