### PR TITLE
[Extractors] Pass thread count into the vmap assembler

### DIFF
--- a/vmap-extractor/assembler.cpp
+++ b/vmap-extractor/assembler.cpp
@@ -25,12 +25,12 @@
 #include "TileAssembler.h"
 #include <string>
 
-bool AssembleVMAP(std::string src, std::string dest, const char* szMagic)
+bool AssembleVMAP(std::string src, std::string dest, const char* szMagic, unsigned int nThreads)
 {
     bool success = true;
     VMAP::TileAssembler* ta = new VMAP::TileAssembler(src, dest);
 
-    if (!ta->convertWorld2(szMagic))
+    if (!ta->convertWorld2(szMagic, nThreads))
     {
         success = false;
     }

--- a/vmap-extractor/vmapexport.cpp
+++ b/vmap-extractor/vmapexport.cpp
@@ -75,7 +75,7 @@
 #define MPQ_BLOCK_SIZE 0x1000
 //-----------------------------------------------------------------------------
 
-bool AssembleVMAP(std::string src, std::string dest, const char* szMagic);
+bool AssembleVMAP(std::string src, std::string dest, const char* szMagic, unsigned int nThreads = 0);
 extern ArchiveSet gOpenArchives;
 
 typedef struct
@@ -871,7 +871,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    success = AssembleVMAP(std::string(szWorkDirWmo), outDir, szRawVMAPMagic);
+    success = AssembleVMAP(std::string(szWorkDirWmo), outDir, szRawVMAPMagic, CONF_threads);
 
     if (!success)
     {


### PR DESCRIPTION
`AssembleVMAP` now forwards the existing `-t/--threads` value (`CONF_threads`,
added in #45) into `TileAssembler::convertWorld2`, so the assembler's per-model
bound pass and model-conversion pass can run across the worker pool. 0 =
auto-detect cores, 1 = serial.

The threaded logic itself lives in each consuming fork's core `TileAssembler`
(the shared repo only holds the plumbing). Companion core PRs:
- Zero: mangoszero/server#415
- One: mangosone/server#129
- Two: mangostwo/server#237

**Ordering:** merge the core PRs first -- they add `convertWorld2`'s `nThreads`
parameter with a default, so they stay compatible with the current extractor.
This shared change requires the updated core header, so it lands after, and each
fork then bumps its `src/tools/Extractor_projects` submodule pointer to pick it
up. Output is unchanged; behaviour only changes when a thread count > 1 is
requested.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/Extractor_projects/47)
<!-- Reviewable:end -->
