### PR TITLE
[Extractors] Keep WMO liquid when a chunk follows MLIQ

### DIFF
--- a/vmap-extractor/wmo.cpp
+++ b/vmap-extractor/wmo.cpp
@@ -149,7 +149,7 @@ WMORoot::~WMORoot()
 }
 
 WMOGroup::WMOGroup(std::string& filename) : filename(filename),
-    MOPY(0), MOVI(0), MoviEx(0), MOVT(0), MOBA(0), MobaEx(0), hlq(0), LiquEx(0), LiquBytes(0)
+    MOPY(0), MOVI(0), MoviEx(0), MOVT(0), MOBA(0), MobaEx(0), LiquEx_size(0), hlq(0), LiquEx(0), LiquBytes(0), liquflags(0)
 {
 }
 
@@ -181,8 +181,6 @@ bool WMOGroup::open()
         }
         fourcc[4] = 0;
         size_t nextpos = f.getPos() + size;
-        LiquEx_size = 0;
-        liquflags = 0;
 
         if (!strcmp(fourcc, "MOGP")) //header
         {


### PR DESCRIPTION
### Problem

`WMOGroup::open()` resets `LiquEx_size` and `liquflags` at the top of **every** chunk iteration:

```cpp
while (!f.isEof())
{
    ...
    LiquEx_size = 0;
    liquflags = 0;
    ...
}
```

So a group's liquid survives only when `MLIQ` is the **last** chunk in the group file. Cataclysm WMO groups place `MOTV`/`MOCV` chunks *after* `MLIQ`, so the next iteration zeroes the liquid state before the write gate `if (LiquEx_size != 0)` runs — the `LIQU` block is never written and the liquid surface is silently lost.

### Impact

Verified against build 15595 client data: of 507 WMO groups carrying `MLIQ`, **91 (18%) have a chunk after `MLIQ`** and lose their liquid — all Cataclysm content (Vashj'ir caves, Obsidian Lair lava, submarines, etc.). In-game this shows as no swim/breath inside those interiors. Example: Darkbrake Cove (`Vashjir_Large_Cave`, WMO 5859) — MLIQ is chunk 14, followed by MOTV/MOCV; its interior water never reached the vmap.

### Fix

Initialize both members once in the constructor instead of per-chunk. Confirmed by re-extraction: `Vashjir_Large_Cave.wmo.vmo` group 0 now carries its 68×107 water surface, and the server reports liquid inside the cove again. Matches TrinityCore's constructor-init approach.

Same fix applied downstream in the vendored copy at mangosthree/server#299.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/Extractor_projects/49)
<!-- Reviewable:end -->
