### PR TITLE
Declare the thread dependency; drop the vendored MD5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,9 @@ target_include_directories(map-extractor
 target_link_libraries(map-extractor
     PUBLIC
     loadlib
+    # Its own sources use std::thread (System.cpp parallelises the map pass).
+    # This linked before only because ACE dragged pthread in; nothing declared it.
+    Threads::Threads
 )
 
 install(
@@ -133,6 +136,7 @@ target_link_libraries(vmap-extractor
     PUBLIC
         loadlib
         vmap2
+        Threads::Threads
 )
 
 install(

--- a/vmap-extractor/vmapexport.cpp
+++ b/vmap-extractor/vmapexport.cpp
@@ -65,7 +65,7 @@
 #include "wmo.h"
 #include <mpq.h>
 #include "vmapexport.h"
-#include "Auth/md5.h"
+#include <openssl/evp.h>
 
 #include "ExtractorCommon.h"
 
@@ -173,18 +173,24 @@ bool FileExists(const char* file)
 
 void compute_md5(const char* value, char* result)
 {
-    md5_byte_t digest[16];
-    md5_state_t ctx;
+    // Hashes a path string into a stable uniform filename -- no security role.
+    // Uses OpenSSL EVP rather than the 383-line vendored MD5 that used to live
+    // in shared/Auth: the tree already links OpenSSL everywhere, so carrying a
+    // second implementation of the same digest bought nothing.
+    unsigned char digest[EVP_MAX_MD_SIZE];
+    unsigned int  length = 0;
 
-    mangos_md5_init(&ctx);
-    md5_append(&ctx, (const unsigned char*)value, strlen(value));
-    md5_finish(&ctx, digest);
+    EVP_MD_CTX* ctx = EVP_MD_CTX_new();
+    EVP_DigestInit_ex(ctx, EVP_md5(), NULL);
+    EVP_DigestUpdate(ctx, value, strlen(value));
+    EVP_DigestFinal_ex(ctx, digest, &length);
+    EVP_MD_CTX_free(ctx);
 
-    for (int i=0;i<16;i++)
+    for (unsigned int i = 0; i < length; ++i)
     {
-        sprintf(result+2*i,"%02x",digest[i]);
+        sprintf(result + 2 * i, "%02x", digest[i]);
     }
-    result[32]='\0';
+    result[2 * length] = 0;
 }
 
 std::string GetUniformName(std::string& path)


### PR DESCRIPTION
Two things that only worked by accident before:

map-extractor and vmap-extractor use std::thread in their own sources but never linked Threads::Threads. ACE dragged pthread in as a side effect, so the link succeeded; with ACE gone it fails. mmap-extractor already declared it.

compute_md5() used the core's shared/Auth/md5.c, a 474-line vendored copy of the RSA reference implementation. It hashes a path string to build a uniform filename -- no security role -- and OpenSSL is already linked here, so it now uses EVP and the vendored copy is deleted from the core.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangos/Extractor_projects/51)
<!-- Reviewable:end -->
